### PR TITLE
Post twitter user data when missing

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,8 +1,11 @@
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /dummycollection/{documnet} {
-      allow read: if true;
-      allow write: if false;
+    match /users/{uid} {
+      allow read, write: if request.auth.uid == uid;
+
+      match /invites/{documnet=**} {
+        allow read, write: if true;
+      }
     }
   }
 }

--- a/src/context/AuthStatusContext/index.js
+++ b/src/context/AuthStatusContext/index.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import firebase, { providerTwitter } from '../../utils/firebase';
+import firebase, { firestore, providerTwitter } from '../../utils/firebase';
 import isequal from 'lodash.isequal'
 
 const AuthStatusContext = React.createContext();
@@ -19,6 +19,26 @@ export class AuthStatusProvider extends React.Component {
         user.getIdToken().then(idToken => {
           this.setState({idToken: idToken});
         }).catch(error => {
+          this.setState({error: error})
+        });
+
+        firestore.collection('users').doc(user.uid).get().then(userDoc => {
+          if(!userDoc.exists 
+            || !userDoc.data().twitter
+            || !userDoc.data().twitter.twitter
+            || !userDoc.data().twitter.access_token
+            || !userDoc.data().twitter.secret            
+          ) {
+            firestore.collection('users').doc(user.uid).set({
+              twitter: {
+                user_id: this.state.result.additionalUserInfo.profile.screen_name,
+                access_token: this.state.result.credential.accessToken,
+                secret: this.state.result.credential.secret,
+              }
+            });
+          }
+        }).catch(error => {
+          //This could be due to `Missing or insufficient permissions` from Firestore rules.
           this.setState({error: error})
         });
       } else {

--- a/src/utils/firebase/index.js
+++ b/src/utils/firebase/index.js
@@ -14,5 +14,9 @@ firebase.initializeApp({
 export const providerGoogle = new firebase.auth.GoogleAuthProvider();
 export const providerFacebook = new firebase.auth.FacebookAuthProvider();
 export const providerTwitter = new firebase.auth.TwitterAuthProvider();
-export const db = firebase.firestore(); //firestroeを使う場合
+export const firestore = firebase.firestore(); //firestroeを使う場合
+// Disable deprecated features
+firestore.settings({
+  timestampsInSnapshots: true
+});
 export default firebase;


### PR DESCRIPTION
Closes #28

This is stupid ... 
but I could not get the twitter user id in from `user` in `firebase.auth().onAuthStateChanged(user => {...})`.

https://firebase.google.com/docs/auth/web/manage-users

See, it's not here:

![2018-11-23_00h10_53](https://user-images.githubusercontent.com/7414320/48911465-15ae4080-eeb6-11e8-88a9-bb714d039d43.png)

but in the Chrome Dev Tool's Network tab - the twitter user id (`screenName`) is retrieved.

![2018-11-23_00h11_45](https://user-images.githubusercontent.com/7414320/48911462-121ab980-eeb6-11e8-9f41-950030151786.png)
